### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: work_tracker/UI_files/auto_generated
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -13,17 +13,17 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/python/black
-    rev: 22.3.0
+    rev: 22.8.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.2 # Use the sha or tag you want to point at
+    rev: v3.0.0-alpha.0 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
   - repo: https://gitlab.com/pycqa/flake8
@@ -47,7 +47,7 @@ repos:
         exclude: "docs|tests"
 
   - repo: https://github.com/myint/rstcheck
-    rev: v5.0.0
+    rev: v6.1.0
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx, rstcheck]
@@ -58,13 +58,13 @@ repos:
       - id: rst-backticks
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
       - id: codespell
         files: ".py|.rst"
 
   - repo: https://github.com/asottile/yesqa
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
       - id: yesqa
         additional_dependencies: [flake8-docstrings]


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/work-tracker/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.20.0-py2.py3-none-any.whl (199 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 199.5/199.5 kB 6.0 MB/s eta 0:00:00
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting pyyaml>=5.1
  Downloading PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (596 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 596.3/596.3 kB 28.0 MB/s eta 0:00:00
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.7.0-py2.py3-none-any.whl (21 kB)
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.16.4-py3-none-any.whl (8.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.8/8.8 MB 100.1 MB/s eta 0:00:00
Collecting identify>=1.0.0
  Downloading identify-2.5.3-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.7/98.7 kB 29.9 MB/s eta 0:00:00
Collecting importlib-metadata
  Downloading importlib_metadata-4.12.0-py3-none-any.whl (21 kB)
Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages (from nodeenv>=0.11.1->pre-commit) (47.1.0)
Collecting distlib<1,>=0.3.5
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 kB 80.0 MB/s eta 0:00:00
Collecting platformdirs<3,>=2.4
  Downloading platformdirs-2.5.2-py3-none-any.whl (14 kB)
Collecting filelock<4,>=3.4.1
  Downloading filelock-3.8.0-py3-none-any.whl (10 kB)
Collecting typing-extensions>=3.6.4
  Downloading typing_extensions-4.3.0-py3-none-any.whl (25 kB)
Collecting zipp>=0.5
  Downloading zipp-3.8.1-py3-none-any.whl (5.6 kB)
Installing collected packages: distlib, zipp, typing-extensions, toml, pyyaml, platformdirs, nodeenv, identify, filelock, cfgv, importlib-metadata, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.6 filelock-3.8.0 identify-2.5.3 importlib-metadata-4.12.0 nodeenv-1.7.0 platformdirs-2.5.2 pre-commit-2.20.0 pyyaml-6.0 toml-0.10.2 typing-extensions-4.3.0 virtualenv-20.16.4 zipp-3.8.1
```



</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... updating v4.2.0 -> v4.3.0.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
updating v2.32.0 -> v2.37.3.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
updating 22.3.0 -> 22.8.0.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
updating v2.6.2 -> v3.0.0-alpha.0.
Updating https://gitlab.com/pycqa/flake8 ... already up to date.
Updating https://github.com/PyCQA/isort ... already up to date.
Updating https://github.com/PyCQA/pydocstyle ... already up to date.
Updating https://github.com/econchick/interrogate ... already up to date.
Updating https://github.com/myint/rstcheck ... [INFO] Initializing environment for https://github.com/myint/rstcheck.
updating v5.0.0 -> v6.1.0.
Updating https://github.com/pre-commit/pygrep-hooks ... already up to date.
Updating https://github.com/codespell-project/codespell ... [INFO] Initializing environment for https://github.com/codespell-project/codespell.
updating v2.1.0 -> v2.2.1.
Updating https://github.com/asottile/yesqa ... [INFO] Initializing environment for https://github.com/asottile/yesqa.
updating v1.3.0 -> v1.4.0.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@3.0.0-alpha.0.
[INFO] Initializing environment for https://github.com/myint/rstcheck:rstcheck,sphinx.
[INFO] Initializing environment for https://github.com/asottile/yesqa:flake8-docstrings.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/econchick/interrogate.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check python ast.........................................................Passed
check builtin type constructor use.......................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
debug statements (python)................................................Passed
fix python encoding pragma...............................................Passed
pyupgrade................................................................Passed
black....................................................................Passed
prettier.................................................................Passed
flake8...................................................................Passed
isort....................................................................Passed
pydocstyle...............................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Failed
- hook id: rstcheck
- exit code: 1

CRITICAL:rstcheck_core.checker:An `AttributeError` error occured. This is most propably due to a code block directive (code/code-block/sourcecode) without a specified language. This may result in a false negative for source: 'docs/authors.rst'. See https://rstcheck-core.readthedocs.io/en/latest/faq/#code-blocks-without-language-sphinx for more information.
CRITICAL:rstcheck_core.checker:An `AttributeError` error occured. This is most propably due to a code block directive (code/code-block/sourcecode) without a specified language. This may result in a false negative for source: 'docs/history.rst'. See https://rstcheck-core.readthedocs.io/en/latest/faq/#code-blocks-without-language-sphinx for more information.
CRITICAL:rstcheck_core.checker:An `AttributeError` error occured. This is most propably due to a code block directive (code/code-block/sourcecode) without a specified language. This may result in a false negative for source: 'docs/contributing.rst'. See https://rstcheck-core.readthedocs.io/en/latest/faq/#code-blocks-without-language-sphinx for more information.
CRITICAL:rstcheck_core.checker:An `AttributeError` error occured. This is most propably due to a code block directive (code/code-block/sourcecode) without a specified language. This may result in a false negative for source: 'docs/readme.rst'. See https://rstcheck-core.readthedocs.io/en/latest/faq/#code-blocks-without-language-sphinx for more information.
docs/modules_functions.rst:7: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/modules_functions.rst:7: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:14: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:14: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:31: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:31: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:50: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:50: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:70: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:70: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:91: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:91: (ERROR/3) Unknown directive type "autosummary".
docs/modules_GUI.rst:7: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/modules_GUI.rst:7: (ERROR/3) Unknown directive type "autosummary".
Error! Issues detected.

rst ``code`` is two backticks............................................Passed
codespell................................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)